### PR TITLE
Support pattern matching of properties when additiona properties is set to false.

### DIFF
--- a/src/engines/json/attributes/additionalProperties.js
+++ b/src/engines/json/attributes/additionalProperties.js
@@ -18,7 +18,14 @@ var additionalPropertiesAttribute = function additionalProperties(property, prop
   // Filter the forbidden properties
   var propertyKeys = keys(propertyValue);
   var forbiddenProperties = filter(propertyKeys, function(key) {
-    return !propertyAttributes.properties[key];
+    if (propertyAttributes.properties) {
+      return !propertyAttributes.properties[key];
+    }
+    // Allow pattern properties to be used without additional properties
+    return !Object.keys(propertyAttributes.patternProperties).some(function(pattern) {
+      var matcher = new RegExp(pattern);
+      return matcher.test(key);
+    });
   });
 
   if (isEmpty(forbiddenProperties)) {

--- a/tests/json/attributes/additionalProperties.js
+++ b/tests/json/attributes/additionalProperties.js
@@ -164,4 +164,101 @@ suite('JSON/Attribute/additionalProperties', function() {
 
   });
 
+  test('false with pattern', function() {
+
+    var count = 0;
+
+    /**
+     * Schema
+     */
+    var schema = {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z]+$": {
+          "type": "array",
+          "minItems": 1,
+          "required": true,
+          "items":{
+            "type":"string"
+          }
+        }
+      },
+      "additionalProperties": false
+    };
+
+    jsonSchemaValidator.validate({
+      "foo": ["bar", "beep", "boop"], "beep": ["boop"]
+    }, schema, function(error) {
+      console.log('1', error);
+      count += 1;
+      expect(error).to.not.be.ok();
+    });
+
+    jsonSchemaValidator.validate({
+      "Foo": ["Bar", "beep", "boop"], "beep": ["boop"]
+    }, schema, function(error) {
+      console.log('2', error);
+      count += 1;
+      expect(error).to.be.ok();
+    });
+
+    jsonSchemaValidator.validate({
+      "foo": ["Bar", "beep", 1234], "beep": ["boop"]
+    }, schema, function(error) {
+      console.log('2', error);
+      count += 1;
+      expect(error).to.be.ok();
+    });
+
+    expect(count).to.be.eql(3);
+  });
+
+  test('true with pattern', function() {
+
+    var count = 0;
+
+    /**
+     * Schema
+     */
+    var schema = {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z]+$": {
+          "type": "array",
+          "required": true,
+          "items":{
+            "type":"string"
+          }
+        }
+      },
+      "additionalProperties": true
+    };
+
+    jsonSchemaValidator.validate({
+      "foo": ["bar", "beep", "boop"], "beep": ["boop"]
+    }, schema, function(error) {
+      console.log('1', error);
+      count += 1;
+      expect(error).to.not.be.ok();
+    });
+
+    jsonSchemaValidator.validate({
+      "Foo": ["Bar", "beep", "boop"], "beep": ["boop"]
+    }, schema, function(error) {
+      console.log('2', error);
+      count += 1;
+      expect(error).to.not.be.ok();
+    });
+
+    jsonSchemaValidator.validate({
+      "foo": ["Bar", "beep", 1234], "beep": ["boop"]
+    }, schema, function(error) {
+      console.log('2', error);
+      count += 1;
+      expect(error).to.be.ok();
+    });
+
+    expect(count).to.be.eql(3);
+  });
+
 });


### PR DESCRIPTION
My team have implemented the Dredd library, which uses Gavel and then Amanda as a dependency.

We have run into an issue where we have `patternProperties` and `additionalProperties` is set to `false` in our JSON schema.

Tests have been included.
